### PR TITLE
Fix XBRL parser and statement section printing

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,18 @@
+# LSTM Code
+
+This repository includes an XBRL parser and related tests.
+
+## Running Tests
+
+Install the dependencies and run pytest:
+
+```bash
+pip install -r requirements.txt -q
+pytest -q
+```
+
+To see example output for the balance sheet, cash flow, and income statement sections, execute the test script directly:
+
+```bash
+python tests/test_xbrl_parser.py
+```

--- a/tests/test_xbrl_parser.py
+++ b/tests/test_xbrl_parser.py
@@ -1,65 +1,43 @@
-import os, sys
-import pprint as pprint
+import os
+import sys
+
 sys.path.append(os.path.dirname(os.path.dirname(__file__)))
 
-from xbrl_parser import extract_numeric_facts, reconstruct_dataframe
+from xbrl_parser import parse_xbrl_files
 
 
-with open('xml_test.txt', 'r') as file:
-    content = file.read()
-    SAMPLE_XML = content
-
-with open('xsd_test.txt', 'r') as file:
-    content = file.read()
-    SAMPLE_XSD = content
-
-
-
-
-"""
-<xbrl xmlns="http://www.xbrl.org/2003/instance" xmlns:us-gaap="http://fasb.org/us-gaap/2020-01-31">
-  <context id="I-2001">
-    <entity>
-      <identifier scheme="http://www.sec.gov/CIK">0000320193</identifier>
-    </entity>
-    <period>
-      <instant>2023-06-30</instant>
-    </period>
-  </context>
-  <unit id="U-Monetary">
-    <measure>iso4217:USD</measure>
-  </unit>
-  <us-gaap:Assets contextRef="I-2001" unitRef="U-Monetary">1000000</us-gaap:Assets>
-  <us-gaap:Liabilities contextRef="I-2001" unitRef="U-Monetary">500000</us-gaap:Liabilities>
-  <us-gaap:Equity contextRef="I-2001" unitRef="U-Monetary">500000</us-gaap:Equity>
-</xbrl>
-"""
-
-"""
-<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" targetNamespace="http://fasb.org/us-gaap/2020-01-31" xmlns:us-gaap="http://fasb.org/us-gaap/2020-01-31" elementFormDefault="qualified">
-  <xs:group name="BalanceSheet">
-    <xs:sequence>
-      <xs:element ref="us-gaap:Assets"/>
-      <xs:element ref="us-gaap:Liabilities"/>
-      <xs:element ref="us-gaap:Equity"/>
-    </xs:sequence>
-  </xs:group>
-  <xs:element name="Assets" type="xs:decimal"/>
-  <xs:element name="Liabilities" type="xs:decimal"/>
-  <xs:element name="Equity" type="xs:decimal"/>
-</xs:schema>
-"""
-
-def test_extract_numeric_facts():
-    facts = extract_numeric_facts(SAMPLE_XML)
-    print(facts)
+def test_parse_xbrl_files():
+    df = parse_xbrl_files("tests/xml_test.txt", "tests/xsd_test.txt")
+    assert not df.empty
+    assert {
+        "label",
+        "footnotes",
+        "references",
+        "presentation_parents",
+        "calculation_parents",
+        "definition_parents",
+        "presentation_roles",
+        "calculation_roles",
+        "definition_roles",
+    }.issubset(df.columns)
+    assert df["footnotes"].dropna().astype(bool).any()
 
 
-def test_reconstruct_dataframe():
-    df = reconstruct_dataframe(SAMPLE_XML, SAMPLE_XSD)
-    pprint.pprint(df)
+if __name__ == "__main__":
+    dataframe = parse_xbrl_files("tests/xml_test.txt", "tests/xsd_test.txt")
 
+    def _print_section(keyword: str) -> None:
+        target = keyword.lower().replace(" ", "")
 
+        def contains_keyword(roles):
+            if not isinstance(roles, list):
+                return False
+            return any(target in (r or "").lower().replace(" ", "") for r in roles)
 
-test_extract_numeric_facts()
-test_reconstruct_dataframe()
+        subset = dataframe[dataframe["presentation_roles"].apply(contains_keyword)]
+        print(f"\n=== {keyword.title()} ===")
+        print(subset[["element", "value", "label"]].head())
+
+    _print_section("balance")
+    _print_section("cash flow")
+    _print_section("income")

--- a/xbrl_parser.py
+++ b/xbrl_parser.py
@@ -1,7 +1,18 @@
 
-from typing import List, Dict
+from typing import List, Dict, Any, Set, Optional
 from lxml import etree
 import pandas as pd
+
+
+def _strip_prefix(name: Optional[str]) -> Optional[str]:
+    """Return local element name without namespace prefix."""
+    if not name:
+        return name
+    if "_" in name:
+        return name.split("_", 1)[1]
+    if ":" in name:
+        return name.split(":", 1)[1]
+    return name
 
 
 def extract_numeric_facts(xbrl_xml: str) -> List[Dict[str, str]]:
@@ -23,6 +34,7 @@ def extract_numeric_facts(xbrl_xml: str) -> List[Dict[str, str]]:
                 continue
 
             facts.append({
+                "id": elem.attrib.get("id"),
                 "element": etree.QName(elem).localname,
                 "value": value,
                 "contextRef": elem.attrib.get("contextRef"),
@@ -38,6 +50,153 @@ def parse_xbrl_file(path: str) -> List[Dict[str, str]]:
     with open(path, "r", encoding="utf-8") as fh:
         xml = fh.read()
     return extract_numeric_facts(xml)
+
+
+def _parse_footnotes(xbrl_xml: str) -> Dict[str, List[str]]:
+    """Return mapping of fact ``id`` to list of associated footnotes."""
+    ns = {
+        "link": "http://www.xbrl.org/2003/linkbase",
+        "xlink": "http://www.w3.org/1999/xlink",
+        "xhtml": "http://www.w3.org/1999/xhtml",
+    }
+    root = etree.fromstring(xbrl_xml.encode("utf-8"))
+    footnotes: Dict[str, List[str]] = {}
+
+    for fn_link in root.findall(".//link:footnoteLink", namespaces=ns):
+        locators = {
+            loc.get("{http://www.w3.org/1999/xlink}label"): loc.get("{http://www.w3.org/1999/xlink}href").lstrip("#")
+            for loc in fn_link.findall("link:loc", namespaces=ns)
+        }
+        notes = {
+            note.get("{http://www.w3.org/1999/xlink}label"): "".join(note.itertext()).strip()
+            for note in fn_link.findall("link:footnote", namespaces=ns)
+        }
+        for arc in fn_link.findall("link:footnoteArc", namespaces=ns):
+            from_lbl = arc.get("{http://www.w3.org/1999/xlink}from")
+            to_lbl = arc.get("{http://www.w3.org/1999/xlink}to")
+            fact_id = locators.get(from_lbl)
+            note_text = notes.get(to_lbl)
+            if fact_id and note_text:
+                footnotes.setdefault(fact_id, []).append(note_text)
+
+    return footnotes
+
+
+def _parse_label_linkbase(xsd_xml: str) -> Dict[str, str]:
+    """Return concept to label mapping from ``labelLink`` elements."""
+    ns = {
+        "link": "http://www.xbrl.org/2003/linkbase",
+        "xlink": "http://www.w3.org/1999/xlink",
+    }
+    root = etree.fromstring(xsd_xml.encode("utf-8"))
+    labels: Dict[str, str] = {}
+
+    for lb in root.findall(".//link:labelLink", namespaces=ns):
+        loc_map = {
+            loc.get("{http://www.w3.org/1999/xlink}label"): _strip_prefix(
+                loc.get("{http://www.w3.org/1999/xlink}href").split("#")[-1]
+            )
+            for loc in lb.findall("link:loc", namespaces=ns)
+        }
+        resources = {
+            res.get("{http://www.w3.org/1999/xlink}label"): "".join(res.itertext()).strip()
+            for res in lb.findall("link:label", namespaces=ns)
+        }
+        for arc in lb.findall("link:labelArc", namespaces=ns):
+            concept = loc_map.get(arc.get("{http://www.w3.org/1999/xlink}from"))
+            label = resources.get(arc.get("{http://www.w3.org/1999/xlink}to"))
+            if concept and label and concept not in labels:
+                labels[concept] = label
+
+    return labels
+
+
+def _parse_reference_linkbase(xsd_xml: str) -> Dict[str, List[str]]:
+    """Return concept to list of reference strings from ``referenceLink``."""
+    ns = {
+        "link": "http://www.xbrl.org/2003/linkbase",
+        "xlink": "http://www.w3.org/1999/xlink",
+        "xhtml": "http://www.w3.org/1999/xhtml",
+    }
+    root = etree.fromstring(xsd_xml.encode("utf-8"))
+    refs: Dict[str, List[str]] = {}
+
+    for ref_link in root.findall(".//link:referenceLink", namespaces=ns):
+        loc_map = {
+            loc.get("{http://www.w3.org/1999/xlink}label"): _strip_prefix(
+                loc.get("{http://www.w3.org/1999/xlink}href").split("#")[-1]
+            )
+            for loc in ref_link.findall("link:loc", namespaces=ns)
+        }
+        resources = {
+            res.get("{http://www.w3.org/1999/xlink}label"): "".join(res.itertext()).strip()
+            for res in ref_link.findall("link:reference", namespaces=ns)
+        }
+        for arc in ref_link.findall("link:referenceArc", namespaces=ns):
+            concept = loc_map.get(arc.get("{http://www.w3.org/1999/xlink}from"))
+            text = resources.get(arc.get("{http://www.w3.org/1999/xlink}to"))
+            if concept and text:
+                refs.setdefault(concept, []).append(text)
+
+    return refs
+
+
+def _parse_roles(xsd_xml: str) -> Dict[str, str]:
+    """Return mapping of role ``id`` to definition string."""
+    ns = {"link": "http://www.xbrl.org/2003/linkbase"}
+    root = etree.fromstring(xsd_xml.encode("utf-8"))
+    roles: Dict[str, str] = {}
+    for rt in root.findall('.//link:roleType', namespaces=ns):
+        role_id = rt.get('id')
+        def_el = rt.find('link:definition', namespaces=ns)
+        definition = ''.join(def_el.itertext()).strip() if def_el is not None else ''
+        if role_id:
+            roles[role_id] = definition
+    return roles
+
+
+def _parse_arcs(root: etree._Element, link_name: str, arc_name: str) -> List[Dict[str, Any]]:
+    ns = {
+        "link": "http://www.xbrl.org/2003/linkbase",
+        "xlink": "http://www.w3.org/1999/xlink",
+    }
+    arcs: List[Dict[str, Any]] = []
+    for link in root.findall(f".//link:{link_name}", namespaces=ns):
+        role = link.get("{http://www.w3.org/1999/xlink}role")
+        loc_map = {
+            loc.get("{http://www.w3.org/1999/xlink}label"): _strip_prefix(
+                loc.get("{http://www.w3.org/1999/xlink}href").split("#")[-1]
+            )
+            for loc in link.findall("link:loc", namespaces=ns)
+        }
+        for arc in link.findall(f"link:{arc_name}", namespaces=ns):
+            from_lbl = arc.get("{http://www.w3.org/1999/xlink}from")
+            to_lbl = arc.get("{http://www.w3.org/1999/xlink}to")
+            arcs.append(
+                {
+                    "from": loc_map.get(from_lbl),
+                    "to": loc_map.get(to_lbl),
+                    "order": arc.get("order"),
+                    "arcrole": arc.get("{http://www.w3.org/1999/xlink}arcrole"),
+                    "role": role,
+                }
+            )
+    return arcs
+
+
+def _parse_linkbases(xbrl_xml: str, xsd_xml: str) -> Dict[str, Any]:
+    """Parse footnotes and various linkbases from XML and XSD."""
+    linkbases: Dict[str, Any] = {}
+    linkbases["footnotes"] = _parse_footnotes(xbrl_xml)
+
+    root = etree.fromstring(xsd_xml.encode("utf-8"))
+    linkbases["labels"] = _parse_label_linkbase(xsd_xml)
+    linkbases["references"] = _parse_reference_linkbase(xsd_xml)
+    linkbases["roles"] = _parse_roles(xsd_xml)
+    linkbases["presentation"] = _parse_arcs(root, "presentationLink", "presentationArc")
+    linkbases["calculation"] = _parse_arcs(root, "calculationLink", "calculationArc")
+    linkbases["definition"] = _parse_arcs(root, "definitionLink", "definitionArc")
+    return linkbases
 
 
 def _parse_xsd_order(xsd_xml: str) -> List[str]:
@@ -80,6 +239,60 @@ def reconstruct_dataframe(xbrl_xml: str, xsd_xml: str) -> pd.DataFrame:
     df = pd.DataFrame(facts)
     if df.empty:
         return df
+
+    linkbases = _parse_linkbases(xbrl_xml, xsd_xml)
+
+    df["label"] = df["element"].map(linkbases.get("labels", {}))
+    df["footnotes"] = df["id"].map(linkbases.get("footnotes", {}))
+    df["references"] = df["element"].map(linkbases.get("references", {}))
+
+    roles = linkbases.get("roles", {})
+
+    def _to_lookup(arcs: List[Dict[str, Any]]) -> Dict[str, List[str]]:
+        lookup: Dict[str, List[str]] = {}
+        for arc in arcs:
+            parent = arc.get("from")
+            child = arc.get("to")
+            if parent and child:
+                lookup.setdefault(child, []).append(parent)
+        return lookup
+
+    def _role_lookup(arcs: List[Dict[str, Any]]) -> Dict[str, List[str]]:
+        lookup: Dict[str, Set[str]] = {}
+        for arc in arcs:
+            child = arc.get("to")
+            role = arc.get("role")
+            if child and role:
+                lookup.setdefault(child, set()).add(role)
+        return {k: list(v) for k, v in lookup.items()}
+
+    df["presentation_parents"] = df["element"].map(
+        _to_lookup(linkbases.get("presentation", []))
+    )
+    df["calculation_parents"] = df["element"].map(
+        _to_lookup(linkbases.get("calculation", []))
+    )
+    df["definition_parents"] = df["element"].map(
+        _to_lookup(linkbases.get("definition", []))
+    )
+
+    df["presentation_roles"] = df["element"].map(
+        _role_lookup(linkbases.get("presentation", []))
+    ).map(
+        lambda roles_list: [roles.get(r.split("#")[-1], r) for r in roles_list] if isinstance(roles_list, list) else roles_list
+    )
+
+    df["calculation_roles"] = df["element"].map(
+        _role_lookup(linkbases.get("calculation", []))
+    ).map(
+        lambda roles_list: [roles.get(r.split("#")[-1], r) for r in roles_list] if isinstance(roles_list, list) else roles_list
+    )
+
+    df["definition_roles"] = df["element"].map(
+        _role_lookup(linkbases.get("definition", []))
+    ).map(
+        lambda roles_list: [roles.get(r.split("#")[-1], r) for r in roles_list] if isinstance(roles_list, list) else roles_list
+    )
 
     order = _parse_xsd_order(xsd_xml)
     order_index = {name: idx for idx, name in enumerate(order)}


### PR DESCRIPTION
## Summary
- strip namespace prefixes when parsing linkbase locators
- map labels, references and arcs using the stripped names
- adjust demo script to match roles ignoring spaces
- document how to run the parser and tests

## Testing
- `pip install -r requirements.txt -q`
- `pytest -q`
- `python tests/test_xbrl_parser.py`


------
https://chatgpt.com/codex/tasks/task_e_685314b02524832dac590290b75bb9ee